### PR TITLE
Update race filter and AI context

### DIFF
--- a/ai_sql.py
+++ b/ai_sql.py
@@ -3,6 +3,8 @@ import os
 import re
 import sqlparse
 from functools import lru_cache
+from typing import Optional
+
 import pandas as pd
 import google.generativeai as genai
 from db import run_query
@@ -222,12 +224,17 @@ SUMMARY_CONTEXT = (
 )
 
 # 3️⃣ Generate SQL from question
-def question_to_sql(question: str) -> tuple[str, str, str]:
-    response = _model().generate_content([
+def question_to_sql(question: str, session_id: Optional[int] = None) -> tuple[str, str, str]:
+    prompt = [
         f"{SYSTEM_CONTEXT}\n\nSchema:\n{SCHEMA_SNIPPET}",
         f"Natural language: {question}",
-        "SQL:"
-    ])
+    ]
+    if session_id is not None:
+        prompt.append(
+            f"The user is interested in data for session_id {session_id}. If appropriate, include a WHERE clause to filter results to this session."
+        )
+    prompt.append("SQL:")
+    response = _model().generate_content(prompt)
 
     raw_text = response.text.strip()
     cleaned_sql = raw_text.strip("`").strip()
@@ -247,7 +254,7 @@ def _summarize(question: str, df: pd.DataFrame) -> str:
     return resp.text.strip()
 
 # 4️⃣ Run query or fallback to raw
-def ask(question: str):
+def ask(question: str, session_id: Optional[int] = None):
     if not os.getenv("GEMINI_API_KEY"):
         return {
             "raw": "",
@@ -257,7 +264,7 @@ def ask(question: str):
             "error": "GEMINI_API_KEY environment variable not set",
         }
     try:
-        sql, raw, _ = question_to_sql(question)
+        sql, raw, _ = question_to_sql(question, session_id)
         parsed = sqlparse.parse(sql)[0]
 
         if parsed.get_type() != "SELECT":

--- a/app.py
+++ b/app.py
@@ -9,7 +9,6 @@ start_ssh_tunnel()
 
 from db import run_query
 from ai_sql import ask
-from refresh_views import refresh  # optional manual refresh UI
 
 st.set_page_config(page_title="F1 Analytics Suite", layout="wide")
 st.title("🏎️ F1 Analytics Suite")
@@ -22,27 +21,20 @@ with st.sidebar:
 
     sessions = run_query(
         """
-        SELECT s.session_id,
-               CONCAT(m.meeting_name,' – ',s.session_name) AS label
+        SELECT DISTINCT s.session_id,
+               m.meeting_name AS label
         FROM session s
         JOIN meeting m ON m.meeting_id = s.meeting_id
-        WHERE m.year = :yr
+        WHERE m.year = :yr AND s.session_type = 'Race'
         ORDER BY m.start
-        """, yr=int(sel_year))
-    session_label = st.selectbox("Session", sessions["label"], index=len(sessions)-1)
+        """,
+        yr=int(sel_year)
+    )
+
+    sessions = sessions.drop_duplicates(subset="session_id")
+    session_label = st.selectbox("Race", sessions["label"], index=len(sessions) - 1)
     session_id = sessions.loc[sessions["label"] == session_label, "session_id"].iat[0]
 
-    # optional manual refresh
-    if st.button("↻ Refresh materialised views"):
-        refresh_all = st.checkbox("Full refresh (can take minutes)", value=False)
-        with st.spinner("Refreshing…"):
-            from refresh_views import refresh_all, VIEWS
-            if refresh_all:
-                refresh_all()
-            else:
-                for v in VIEWS:
-                    refresh(v)
-        st.success("Done!")
 
 # ───────────────────────── Tabs ──────────────────────────
 tab_race, tab_lap, tab_stint, tab_pit, tab_sector, tab_season, tab_ai = st.tabs(
@@ -186,7 +178,7 @@ with tab_ai:
         q = st.text_input("Ask something about the F1 data")
         if st.button("Run AI query") and q:
             with st.spinner("Gemini Flash is thinking…"):
-                res = ask(q)
+                res = ask(q, session_id)
             st.session_state.ai_history.append((q, res))
             if res.get("sql"):
                 st.session_state.manual_sql = res["sql"]


### PR DESCRIPTION
## Summary
- remove materialised view refresh UI
- restrict sidebar session selector to races only
- deduplicate races in filter query
- pass the selected race to the AI helper so generated SQL uses the same session
- fix type hints for Python 3.9 compatibility

## Testing
- `python -m py_compile app.py ai_sql.py db.py refresh_views.py ssh_tunnel.py cleanup_tunnel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68839c9690288321b8907ae66a56d4f8